### PR TITLE
FEATURE: Add possibility to load simplepoll by using Typoscript

### DIFF
--- a/Classes/Controller/SimplePollController.php
+++ b/Classes/Controller/SimplePollController.php
@@ -87,6 +87,18 @@ class SimplePollController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionContr
      */
     public function listAction()
     {
+        // Use stdWrap for settings.simplepoll.uid
+        if (isset($this->settings['simplepoll']['useStdWrap']) && !empty($this->settings['simplepoll']['useStdWrap'])) {
+            $typoScriptService = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\TypoScript\TypoScriptService::class);
+            $typoScriptArray = $typoScriptService->convertPlainArrayToTypoScriptArray($this->settings);
+            $typoScriptArray = $typoScriptArray['simplepoll.'];
+
+            $this->settings['simplepoll']['uid'] = $this->configurationManager->getContentObject()->stdWrap(
+                $typoScriptArray['uid'],
+                $typoScriptArray['uid.']
+            );
+        }
+        
         //this selects the poll given in the plugin itself
         $simplePoll = $this->simplePollRepository->findByUid($this->settings['simplepoll']['uid']);
         if (!$simplePoll) {

--- a/Documentation/AdministratorManual/Index.rst
+++ b/Documentation/AdministratorManual/Index.rst
@@ -89,8 +89,41 @@ Block multiple votes from one computer via cookies - ``[plugin.tx_simplepoll.set
 	Note that this method is a lot less secure than the IP block. If a cookie block is enabled a check is performed if the users browser accepts cookies.
 |
 
+Load simplepoll via Typoscript
+------------------------------
 
+You can load the simplepoll Plugin by using the following Typoscript lib:
 
+.. code-block:: typoscript
+
+	lib.loadSimplepoll = USER
+	lib.loadSimplepoll {
+		userFunc = TYPO3\CMS\Extbase\Core\Bootstrap->run
+		extensionName = Simplepoll
+		pluginName = Polllisting
+		vendorName = Pixelink
+
+		switchableControllerActions {
+			SimplePoll {
+				1 = list
+			}
+		}
+
+		settings {
+			simplepoll {
+				useStdWrap := addToList(uid)
+				uid.current = 1
+			}
+		}
+	}
+
+Call ``lib.loadSimplepoll`` with the following code in your fluid template:
+
+.. code-block:: html
+
+	<f:cObject typoscriptObjectPath="lib.loadSimplepoll">2</f:cObject>
+
+This example will load the poll with the uid 2.
 
 
 


### PR DESCRIPTION
The applied changes make it possible to load a specific poll by using Typoscript. This is for example usefull if you want to add a poll below a news entry of ext:news, where you can't just add the plugin.

You could give editors the option to add the poll uid in the news record and call the plugin in the template:

    <f:if condition="{newsItem.ipgSimplepoll}">
        <f:cObject typoscriptObjectPath="lib.loadSimplepoll">{newsItem.simplepoll}</f:cObject>
    </f:if>

And here is the `lib.loadSimplepoll`:

    lib.loadSimplepoll = USER
    lib.loadSimplepoll {
        userFunc = TYPO3\CMS\Extbase\Core\Bootstrap->run
        extensionName = Simplepoll
        pluginName = Polllisting
        vendorName = Pixelink

        switchableControllerActions {
            SimplePoll {
                1 = list
            }
        }

        settings {
            simplepoll {
                useStdWrap := addToList(uid)
                uid.current = 1
            }
        }
    }