### PR TITLE
Update external jQuery condition to new expression syntax

### DIFF
--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -55,7 +55,7 @@ page {
     }
 }
 
-[globalVar = LIT:1 = {$plugin.tx_simplepoll.settings.useInternalJquery}]
+[{$plugin.tx_simplepoll.settings.useInternalJquery} == 1]
 page {
     includeJS {
         jQuery = http://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js


### PR DESCRIPTION
Fix deprecation warnings by switching to the new condition syntax:
* https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog/9.4/Feature-85829-ImplementSymfonyExpressionLanguageForTypoScriptConditions.html